### PR TITLE
feat(story-3.3): Add conversation list API with pagination

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -63,7 +63,7 @@ development_status:
   epic-3: in-progress
   3-1-conversation-history-scroll: done
   3-2-conversation-history-db-persistence: done
-  3-3-conversation-list-api: backlog
+  3-3-conversation-list-api: done
   3-4-conversation-detail-view: backlog
   3-5-conversation-history-delete: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/implementation-artifacts/stories/3-3-conversation-list-api.md
+++ b/_bmad-output/implementation-artifacts/stories/3-3-conversation-list-api.md
@@ -1,0 +1,254 @@
+# Story 3.3: 会話履歴一覧API
+
+Status: done
+
+## Story
+
+As a **ユーザー**,
+I want **過去の会話一覧を取得できる**,
+so that **以前の会話を選択して閲覧できる** (FR17).
+
+## Acceptance Criteria
+
+1. **Given** 複数の会話がDBに保存されている
+   **When** `GET /api/v1/conversations`を呼び出す
+   **Then** 会話一覧がJSON形式で返される
+
+2. **And** 各会話にid、title、created_at、updated_atが含まれる
+
+3. **And** 新しい順（updated_at DESC）にソートされる
+
+4. **And** ページネーション対応（limit/offset クエリパラメータ）
+
+5. **And** 空の場合は空配列を返す（エラーではない）
+
+## Tasks / Subtasks
+
+- [x] Task 1: 会話一覧レスポンスモデル定義 (AC: #2)
+  - [x] `ConversationListItem` モデル作成（messages無しの軽量版）
+  - [x] `ConversationListResponse` with meta情報（total, page, limit）
+
+- [x] Task 2: `GET /api/v1/conversations` エンドポイント実装 (AC: #1, #3, #4, #5)
+  - [x] クエリパラメータ: `limit` (default: 20, max: 100), `offset` (default: 0)
+  - [x] `ConversationRepository.list_all()` を使用
+  - [x] 空の場合は空配列を返す
+
+- [x] Task 3: 総件数取得機能追加 (AC: #4)
+  - [x] `ConversationRepository.count()` メソッド追加
+  - [x] レスポンスの `meta.total` に総件数を含める
+
+- [x] Task 4: テスト実装 (AC: #1-5)
+  - [x] 空の場合のテスト
+  - [x] 複数会話存在時のテスト
+  - [x] ページネーションテスト（limit/offset）
+  - [x] ソート順テスト（updated_at DESC）
+
+- [x] Task 5: ビルド確認 (AC: #1-5)
+  - [x] uv run pytest 全テスト合格 (45件 conversation/DB tests pass)
+  - [x] npm run lint / npm run build 確認
+
+## Dev Notes
+
+### アーキテクチャ準拠事項
+
+**Architecture.md からの要件:**
+
+```
+REST エンドポイント:
+GET    /api/v1/conversations       # 会話一覧
+```
+
+**API Response Patterns (Architecture.md):**
+```json
+// リストレスポンス
+{
+  "data": [...],
+  "meta": { "total": 100, "page": 1, "limit": 20 }
+}
+```
+
+**命名規則:**
+- エンドポイント: kebab-case 複数形 (`/api/v1/conversations`)
+- クエリパラメータ: snake_case (`page_size`, `offset`)
+
+### 既存実装の活用
+
+**Story 3.2 で実装済み:**
+
+`backend/src/voice_assistant/db/repository.py`:
+```python
+class ConversationRepository:
+    def list_all(self, limit: int = 50, offset: int = 0) -> list[Conversation]:
+        """List conversations ordered by updated_at descending."""
+        statement = (
+            select(Conversation)
+            .order_by(Conversation.updated_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        return list(self.session.exec(statement).all())
+```
+
+`backend/src/voice_assistant/main.py`:
+- 既存の `ConversationResponse` モデル（messages含む）
+- `/api/v1/conversations/latest` エンドポイント
+- `/api/v1/conversations/{id}` エンドポイント
+
+### 技術仕様
+
+**新規レスポンスモデル:**
+```python
+class ConversationListItem(BaseModel):
+    """Response model for conversation list item (without messages)."""
+    id: str
+    title: str | None
+    created_at: datetime
+    updated_at: datetime
+
+class ConversationListMeta(BaseModel):
+    """Pagination metadata."""
+    total: int
+    limit: int
+    offset: int
+
+class ConversationListResponse(BaseModel):
+    """Response model for conversation list."""
+    data: list[ConversationListItem]
+    meta: ConversationListMeta
+```
+
+**新規エンドポイント:**
+```python
+@app.get("/api/v1/conversations")
+async def list_conversations(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> ConversationListResponse:
+    """Get list of conversations with pagination.
+
+    Args:
+        limit: Maximum number of conversations (1-100, default: 20)
+        offset: Number of conversations to skip (default: 0)
+
+    Returns:
+        List of conversations with pagination metadata.
+    """
+    with Session(get_engine()) as session:
+        conv_repo = ConversationRepository(session)
+        conversations = conv_repo.list_all(limit=limit, offset=offset)
+        total = conv_repo.count()
+
+        return ConversationListResponse(
+            data=[
+                ConversationListItem(
+                    id=conv.id,
+                    title=conv.title,
+                    created_at=conv.created_at,
+                    updated_at=conv.updated_at,
+                )
+                for conv in conversations
+            ],
+            meta=ConversationListMeta(
+                total=total,
+                limit=limit,
+                offset=offset,
+            ),
+        )
+```
+
+**Repository拡張:**
+```python
+# ConversationRepository に追加
+def count(self) -> int:
+    """Get total number of conversations.
+
+    Returns:
+        Total count of conversations
+    """
+    statement = select(func.count()).select_from(Conversation)
+    return self.session.exec(statement).one()
+```
+
+### Previous Story Learnings
+
+**Story 3.2 から:**
+- `ConversationRepository.list_all()` は既に `updated_at DESC` でソート済み
+- FK constraints は `PRAGMA foreign_keys=ON` で有効化済み
+- Session management は `with Session(get_engine())` パターンを使用
+- 既存の94テストがパス（リグレッションチェック必須）
+
+**Code Review で指摘された事項:**
+- 返り値の型アノテーション整合性に注意
+- セッションエラーハンドリングは明示的に
+
+### ディレクトリ構造
+
+```
+backend/src/voice_assistant/
+├── main.py                # ← GET /api/v1/conversations 追加
+└── db/
+    └── repository.py      # ← count() メソッド追加
+```
+
+### テスト基準
+
+1. 会話0件の場合、空配列 `{ data: [], meta: { total: 0, ... } }` を返す
+2. 複数会話存在時、updated_at 降順でソートされる
+3. limit パラメータで取得件数が制限される
+4. offset パラメータでスキップが機能する
+5. limit の範囲外（0以下、101以上）はバリデーションエラー
+6. 全既存テスト（94件）がパスする（リグレッションなし）
+
+### NFR考慮事項
+
+**パフォーマンス:**
+- limit のデフォルト20、最大100で過剰なデータ取得を防止
+- COUNT クエリは軽量（インデックスなしでも許容範囲）
+
+**API設計:**
+- Architecture.md の `{ data: [...], meta: {...} }` パターンに準拠
+- 空の場合は404ではなく空配列を返す（RESTful設計）
+
+### References
+
+- [Source: _bmad-output/architecture.md#REST エンドポイント]
+- [Source: _bmad-output/architecture.md#API Response Patterns]
+- [Source: _bmad-output/project-planning-artifacts/epics.md#Story-3.3]
+- [Source: backend/src/voice_assistant/db/repository.py#ConversationRepository.list_all]
+- [Source: backend/src/voice_assistant/main.py#existing endpoints]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-5-20251101
+
+### Debug Log References
+
+N/A - No debug issues encountered
+
+### Completion Notes List
+
+- **Task 1:** Added `ConversationListItem`, `ConversationListMeta`, and `ConversationListResponse` Pydantic models in `main.py`. `ConversationListItem` is a lightweight model without messages for list view. Response follows Architecture.md pattern `{ data: [...], meta: {...} }`.
+
+- **Task 2:** Implemented `GET /api/v1/conversations` endpoint with query parameters `limit` (default: 20, range: 1-100) and `offset` (default: 0, min: 0). Uses FastAPI `Query` for validation. Returns empty array with `total: 0` when no conversations exist.
+
+- **Task 3:** Added `count()` method to `ConversationRepository` using `select(func.count()).select_from(Conversation)`. Added `func` import from sqlalchemy.
+
+- **Task 4:** Added 9 new tests in `TestListConversations` class covering: empty case, list with data, sorting by updated_at DESC, limit/offset pagination, validation errors for out-of-range parameters, and field presence verification. Also added 2 unit tests for `count()` method.
+
+- **Task 5:** All 45 conversation/DB tests pass. Frontend lint and build successful.
+
+### File List
+
+**Modified Files:**
+- `backend/src/voice_assistant/main.py` - Added 3 response models and `GET /api/v1/conversations` endpoint
+- `backend/src/voice_assistant/db/repository.py` - Added `count()` method and `func` import
+- `backend/tests/integration/test_conversation_api.py` - Added `TestListConversations` class with 9 tests
+- `backend/tests/integration/test_db_repository.py` - Added 2 tests for `count()` method
+
+## Change Log
+
+- 2025-12-27: Code review passed - added edge case test for offset >= total (12 tests total for this story)
+- 2025-12-27: Story 3.3 implementation complete - GET /api/v1/conversations endpoint with pagination, 11 new tests added
+

--- a/backend/src/voice_assistant/db/repository.py
+++ b/backend/src/voice_assistant/db/repository.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
-from sqlalchemy import event
+from sqlalchemy import event, func
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from voice_assistant.db.models import Conversation, Message, generate_id, utc_now
@@ -141,6 +141,15 @@ class ConversationRepository:
             .limit(limit)
         )
         return list(self.session.exec(statement).all())
+
+    def count(self) -> int:
+        """Get total number of conversations.
+
+        Returns:
+            Total count of conversations
+        """
+        statement = select(func.count()).select_from(Conversation)
+        return self.session.exec(statement).one()
 
     def update(
         self, conversation_id: str, title: str | None = None

--- a/backend/tests/integration/test_db_repository.py
+++ b/backend/tests/integration/test_db_repository.py
@@ -128,6 +128,21 @@ class TestConversationRepository:
         # Should skip first 2
         assert convs[0].title == "Conv 2"
 
+    def test_count_empty_db(self, session):
+        """Should return 0 when no conversations exist."""
+        repo = ConversationRepository(session)
+        count = repo.count()
+        assert count == 0
+
+    def test_count_with_conversations(self, session):
+        """Should return total number of conversations."""
+        repo = ConversationRepository(session)
+        for i in range(5):
+            repo.create(title=f"Conv {i}")
+
+        count = repo.count()
+        assert count == 5
+
     def test_update_conversation_title(self, session):
         """Should update conversation title."""
         repo = ConversationRepository(session)


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/conversations` endpoint with pagination support (limit/offset)
- Add response models: `ConversationListItem`, `ConversationListMeta`, `ConversationListResponse`
- Add `ConversationRepository.count()` method for total count
- Add 12 tests covering all acceptance criteria and edge cases

## Acceptance Criteria (All Met)

- ✅ `GET /api/v1/conversations` returns JSON conversation list
- ✅ Each conversation includes id, title, created_at, updated_at
- ✅ Sorted by updated_at DESC (newest first)
- ✅ Pagination with limit (1-100, default: 20) and offset (default: 0)
- ✅ Returns empty array (not 404) when no conversations exist

## Test Plan

- [x] 10 API integration tests in `TestListConversations`
- [x] 2 repository unit tests for `count()` method
- [x] Edge case: offset exceeds total returns empty list
- [x] Validation: limit < 1, limit > 100, offset < 0 return 422

## Files Changed

- `backend/src/voice_assistant/main.py` - API endpoint and models
- `backend/src/voice_assistant/db/repository.py` - count() method
- `backend/tests/integration/test_conversation_api.py` - 10 new tests
- `backend/tests/integration/test_db_repository.py` - 2 new tests

## Related Story

Closes Story 3.3: 会話履歴一覧API (FR17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)